### PR TITLE
minor nav merge issues

### DIFF
--- a/client/src/Admin/AdminBlockPage.tsx
+++ b/client/src/Admin/AdminBlockPage.tsx
@@ -311,8 +311,7 @@ function AdminBlockPage() {
                     student.name,
                     student.coach,
                     <a
-                      href={`/admin/notes/${student.studentId}`}
-                      target="_blank"
+                      href={`/admin-notes/${student.studentId}`}
                       rel="noopener noreferrer"
                     >
                       Notes

--- a/client/src/components/PageHeader.tsx
+++ b/client/src/components/PageHeader.tsx
@@ -76,7 +76,7 @@ export default function Header() {
     navigator(`/student/progress/${studentId}`);
   };
   const handleFamilyLesson = () => {
-    navigator('/lessons');
+    navigator('/student/lessons');
   };
   // Coach Onclick Functions
   const handleCoachProgress = () => {
@@ -204,7 +204,7 @@ export default function Header() {
           )}
           {user && user.role === 'parent' ? (
             <div>
-              {!location.pathname.includes('/student-progress') ? (
+              {!location.pathname.includes('/student/progress/') ? (
                 <Button
                   sx={{
                     color: 'white',
@@ -217,10 +217,8 @@ export default function Header() {
                 >
                   Progress
                 </Button>
-              ) : (
-                false
-              )}
-              {!location.pathname.includes('/lessons') ? (
+              ) : null}
+              {!location.pathname.includes('lessons') ? (
                 <Button
                   sx={{
                     color: 'white',
@@ -233,9 +231,7 @@ export default function Header() {
                 >
                   Lessons
                 </Button>
-              ) : (
-                false
-              )}
+              ) : null}
             </div>
           ) : (
             false


### PR DESCRIPTION
Fixed: 
1. 
http://localhost:3000/admin/block/6563df3e9a4b8046a264038f
The ‘notes’ link goes to a new page and also doesn’t work (404)
Goes to: http://localhost:3000/admin/notes/652b7d82184da481b5fad533

2.
From: http://localhost:3000/student/progress/6510857e100eb371707ca8e7
The lesson button should be to a diff link, and progress button should vanish?
currently: http://localhost:3000/lessons
Should be: http://localhost:3000/student/lessons
